### PR TITLE
Refactor retry logic to clone requests

### DIFF
--- a/lib/fetchApi.ts
+++ b/lib/fetchApi.ts
@@ -60,14 +60,15 @@ async function tryFetchWithRetry(
 ): Promise<Response> {
   let lastError;
   for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), timeoutMs);
-      const res = await fetch(request, { signal: controller.signal });
+      const res = await fetch(request.clone(), { signal: controller.signal });
       clearTimeout(timeout);
       return res;
     } catch (err) {
       lastError = err;
+      clearTimeout(timeout);
       if (attempt === retries) throw err;
       await new Promise(r => setTimeout(r, 250)); // kleine delay tussen retries
     }


### PR DESCRIPTION
## Summary
- move AbortController setup outside try block in `tryFetchWithRetry`
- clone request per retry
- always clear timers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684188af2710832c9ad01a7b774857d3