### PR TITLE
Enable dynamic sidebar groups

### DIFF
--- a/components/organisms/nav-main.tsx
+++ b/components/organisms/nav-main.tsx
@@ -29,7 +29,12 @@ interface NavItem {
   items?: NavItem[];
 }
 
-export function NavMain({ items }: { items: NavItem[] }) {
+interface NavGroup {
+  label: string;
+  items: NavItem[];
+}
+
+export function NavMain({ groups }: { groups: NavGroup[] }) {
   const renderNavItem = (item: NavItem, level: number = 0) => {
     const hasItems = item.items && item.items.length > 0;
     const isFirstLevel = level === 0;
@@ -77,9 +82,17 @@ export function NavMain({ items }: { items: NavItem[] }) {
   };
 
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel className="text-white">Boilerplate</SidebarGroupLabel>
-      <SidebarMenu>{items.map(item => renderNavItem(item))}</SidebarMenu>
-    </SidebarGroup>
+    <>
+      {groups.map(group => (
+        <SidebarGroup key={group.label}>
+          <SidebarGroupLabel className="text-white">
+            {group.label}
+          </SidebarGroupLabel>
+          <SidebarMenu>
+            {group.items.map(item => renderNavItem(item))}
+          </SidebarMenu>
+        </SidebarGroup>
+      ))}
+    </>
   );
 }

--- a/components/templates/app-sidebar.tsx
+++ b/components/templates/app-sidebar.tsx
@@ -47,76 +47,81 @@ const data = {
   ],
   navMain: [
     {
-      title: 'Huisstijl',
-      url: '/huisstijl',
-      icon: Palette,
-      isActive: false,
-    },
-    {
-      title: 'Examples',
-      url: '/voorbeelden',
-      icon: Code,
-      isActive: true,
+      label: 'Boilerplate',
       items: [
         {
-          title: 'RJSF Form',
-          url: '/voorbeelden/rjsf',
-          icon: FormInput,
+          title: 'Huisstijl',
+          url: '/huisstijl',
+          icon: Palette,
+          isActive: false,
+        },
+        {
+          title: 'Examples',
+          url: '/voorbeelden',
+          icon: Code,
+          isActive: true,
           items: [
             {
-              title: 'Standard',
-              url: '/voorbeelden/rjsf/standard',
+              title: 'RJSF Form',
+              url: '/voorbeelden/rjsf',
+              icon: FormInput,
+              items: [
+                {
+                  title: 'Standard',
+                  url: '/voorbeelden/rjsf/standard',
+                },
+                {
+                  title: 'Variables',
+                  url: '/voorbeelden/rjsf/env-properties',
+                },
+              ],
             },
             {
-              title: 'Variables',
-              url: '/voorbeelden/rjsf/env-properties',
+              title: 'Badge',
+              url: '/voorbeelden/badge',
+              icon: Tag,
+            },
+            {
+              title: 'Button',
+              url: '/voorbeelden/button',
+              icon: SquarePlay,
+            },
+            {
+              title: 'Card',
+              url: '/voorbeelden/card',
+              icon: LayoutGrid,
+            },
+            {
+              title: 'Loading Screen',
+              url: '/voorbeelden/skeleton',
+              icon: SquareTerminal,
+            },
+            {
+              title: 'Form Components',
+              url: '/voorbeelden/form',
+              icon: ClipboardEdit,
+            },
+            {
+              title: 'Alert',
+              url: '/voorbeelden/alert',
+              icon: AlertTriangle,
+            },
+            {
+              title: 'Alert Dialog',
+              url: '/voorbeelden/alert-dialog',
+              icon: AlertCircle,
+            },
+            {
+              title: 'Notification (Sonner)',
+              url: '/voorbeelden/sonner',
+              icon: Bell,
+            },
+            {
+              title: 'Sheet',
+              url: '/voorbeelden/sheet',
+              icon: Command,
             },
           ],
-        },
-        {
-          title: 'Badge',
-          url: '/voorbeelden/badge',
-          icon: Tag,
-        },
-        {
-          title: 'Button',
-          url: '/voorbeelden/button',
-          icon: SquarePlay,
-        },
-        {
-          title: 'Card',
-          url: '/voorbeelden/card',
-          icon: LayoutGrid,
-        },
-        {
-          title: 'Loading Screen',
-          url: '/voorbeelden/skeleton',
-          icon: SquareTerminal,
-        },
-        {
-          title: 'Form Components',
-          url: '/voorbeelden/form',
-          icon: ClipboardEdit,
-        },
-        {
-          title: 'Alert',
-          url: '/voorbeelden/alert',
-          icon: AlertTriangle,
-        },
-        {
-          title: 'Alert Dialog',
-          url: '/voorbeelden/alert-dialog',
-          icon: AlertCircle,
-        },
-        {
-          title: 'Notification (Sonner)',
-          url: '/voorbeelden/sonner',
-          icon: Bell,
-        },
-        {
-          title: 'Sheet',
-          url: '/voorbeelden/sheet',
-          icon: Command,
         },
       ],
     },
@@ -144,7 +149,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <ProjectSwitcher projects={data.projects} />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain groups={data.navMain} />
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter className="flex items-center justify-between px-4">


### PR DESCRIPTION
## Summary
- add `NavGroup` definition and update `NavMain` to render groups dynamically
- extend sidebar data structure with group label
- update sidebar template to pass group data to `NavMain`

## Testing
- `npm run format` *(fails: Cannot find package '@trivago/prettier-plugin-sort-imports')*
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418da82aa4832cb9176e59d68493ed