### PR TITLE
Export NavGroup interface

### DIFF
--- a/components/organisms/nav-main.tsx
+++ b/components/organisms/nav-main.tsx
@@ -21,16 +21,16 @@ import {
   SidebarMenuSubItem,
 } from '@/components/organisms/sidebar';
 
-interface NavItem {
+export interface NavGroup {
   title: string;
   url: string;
   icon?: LucideIcon;
   isActive?: boolean;
-  items?: NavItem[];
+  items?: NavGroup[];
 }
 
-export function NavMain({ items }: { items: NavItem[] }) {
-  const renderNavItem = (item: NavItem, level: number = 0) => {
+export function NavMain({ items }: { items: NavGroup[] }) {
+  const renderNavItem = (item: NavGroup, level: number = 0) => {
     const hasItems = item.items && item.items.length > 0;
     const isFirstLevel = level === 0;
 

--- a/components/templates/app-sidebar.tsx
+++ b/components/templates/app-sidebar.tsx
@@ -19,9 +19,10 @@ import {
   SquarePlay,
   SquareTerminal,
   Tag,
+  type LucideIcon,
 } from 'lucide-react';
 
-import { NavMain } from '@/components/organisms/nav-main';
+import { NavMain, type NavGroup } from '@/components/organisms/nav-main';
 import { NavSecondary } from '@/components/organisms/nav-secondary';
 import { NavUser } from '@/components/organisms/nav-user';
 import { ProjectSwitcher } from '@/components/organisms/project-switcher';
@@ -32,7 +33,11 @@ import {
   SidebarHeader,
 } from '@/components/organisms/sidebar';
 
-const data = {
+const data: {
+  projects: { name: string; logo: LucideIcon; plan: string }[];
+  navMain: NavGroup[];
+  navSecondary: { title: string; url: string; icon: LucideIcon }[];
+} = {
   projects: [
     {
       name: 'SSP 2.0',


### PR DESCRIPTION
## Summary
- export `NavGroup` from `NavMain`
- type `navMain` data using `NavGroup[]`
- import `NavGroup` in `AppSidebar`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841996d0f0c832c90ca81c340005340