### PR TITLE
Update navMain typing

### DIFF
--- a/components/organisms/nav-main.tsx
+++ b/components/organisms/nav-main.tsx
@@ -29,7 +29,7 @@ interface NavItem {
   items?: NavItem[];
 }
 
-interface NavGroup {
+export interface NavGroup {
   label: string;
   items: NavItem[];
 }

--- a/components/templates/app-sidebar.tsx
+++ b/components/templates/app-sidebar.tsx
@@ -21,7 +21,7 @@ import {
   Tag,
 } from 'lucide-react';
 
-import { NavMain } from '@/components/organisms/nav-main';
+import { NavMain, type NavGroup } from '@/components/organisms/nav-main';
 import { NavSecondary } from '@/components/organisms/nav-secondary';
 import { NavUser } from '@/components/organisms/nav-user';
 import { ProjectSwitcher } from '@/components/organisms/project-switcher';
@@ -125,7 +125,7 @@ const data = {
         },
       ],
     },
-  ],
+  ] as NavGroup[],
   navSecondary: [
     {
       title: 'Help Center',


### PR DESCRIPTION
## Summary
- export NavGroup type from NavMain component
- import NavGroup in `AppSidebar`
- annotate `navMain` data as `NavGroup[]`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*
- `npm run format` *(fails: prettier plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68429d20d36c832c8d1d471af2b647b6